### PR TITLE
bugfix/accurics_remediation_14732337433469977 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/aws/modules/storage/main.tf
+++ b/terraform/aws/modules/storage/main.tf
@@ -61,6 +61,7 @@ resource "aws_db_instance" "km_db" {
   tags = merge(var.default_tags, {
     Name = "km_db_${var.environment}"
   })
+  iam_database_authentication_enabled = true
 }
 
 resource "aws_ssm_parameter" "km_ssm_db_host" {


### PR DESCRIPTION
You can authenticate to your DB instance using AWS Identity and Access Management (IAM) database authentication. IAM database authentication works with MySQL and PostgreSQL. With this authentication method, you don't need to use a password when you connect to a DB instance. Instead, you use an authentication token.